### PR TITLE
[fix] report error when overflow

### DIFF
--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -31,7 +31,7 @@ QString ScanOrParseError::getMsg() const {
 }
 
 QString InvalidInput::getMsg() const {
-    return "Input must be an integer!";
+    return "Input must be an integer within valid range!";
 }
 
 PowerError::PowerError(const QString& errorMsg): errorMsg(errorMsg) { }

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -109,7 +109,11 @@ TokenPtr Scanner::getNumber() {
         ++current;
     }
     QString numString = source.mid(start, current - start).toString();
-    int val = numString.toInt();
+    bool ok;
+    int val = numString.toInt(&ok);
+    if (!ok) {
+        throw numString + QString(" is not within valid range!");
+    }
     return make_shared<Token>(TokenType::NUMBER, numString, val);
 }
 


### PR DESCRIPTION
Make all integers beyond the range of `i32` invalid and report error correspondingly.